### PR TITLE
Add env to git actions to ensure permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,6 +43,8 @@ jobs:
           git push --set-upstream origin feature/v${{ github.event.inputs.version }}
           git tag v${{ github.event.inputs.version }}
           git push origin v${{ github.event.inputs.version }}
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Release with build files
       run: |
         ls -al ./com.reflexit.magiccards.product


### PR DESCRIPTION
the "git commit" and "git push" actions in the github actions automation needs permissions, so add the github token to the env, so that when the github token is granted the correct set of permissions:
"commit"
"push"
"create pull request"
"create release"

it will be able to perform all the required actions